### PR TITLE
Velocity and Bungee Refactor and config improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,19 @@
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "1.5.21"
-    id "org.jetbrains.kotlin.kapt" version "1.5.21"
-    id "net.kyori.blossom" version "1.3.0"
-    id "com.github.johnrengelman.shadow" version "7.0.0"
+    id "org.jetbrains.kotlin.jvm" version "1.9.22"
+    id "org.jetbrains.kotlin.kapt" version "1.9.22"
+    id "com.gradleup.shadow" version "8.3.0"
 }
 
 group 'lv.mtm123'
 version '1.2.0-SNAPSHOT'
 
-apply plugin: "com.github.johnrengelman.shadow"
-
-blossom {
-    replaceToken("@version@", version)
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
+
+
+
 
 processResources {
     filter { String line -> line.replace("@version@", version) }
@@ -31,8 +32,8 @@ build.dependsOn shadowJar
 repositories {
     mavenCentral()
     maven {
-        name 'velocity'
-        url 'https://repo.velocitypowered.com/snapshots/'
+        name 'papermc'
+        url 'https://repo.papermc.io/repository/maven-public/'
     }
     maven {
         name = 'sonatype'
@@ -49,18 +50,15 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.21'
-    compileOnly 'com.velocitypowered:velocity-api:3.0.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.22'
+    compileOnly 'com.velocitypowered:velocity-api:3.5.0-SNAPSHOT'
     compileOnly 'net.md-5:bungeecord-api:1.16-R0.4'
     implementation 'org.spongepowered:configurate-yaml:4.1.1'
     implementation 'org.bstats:bstats-bungeecord:2.2.1'
     implementation 'org.bstats:bstats-velocity:2.2.1'
-    kapt 'com.velocitypowered:velocity-api:1.0.0-SNAPSHOT'
+    kapt 'com.velocitypowered:velocity-api:3.5.0-SNAPSHOT'
 }
 
-compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions.jvmTarget = "21"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/lv/mtm123/slashserver/proxies/BungeeSlashServer.kt
+++ b/src/main/kotlin/lv/mtm123/slashserver/proxies/BungeeSlashServer.kt
@@ -1,34 +1,66 @@
 package lv.mtm123.slashserver.proxies
 
-import lv.mtm123.slashserver.cmd.BungeeNavigationCommand
 import lv.mtm123.slashserver.util.Config
-import lv.mtm123.slashserver.util.ServerEntry
 import net.md_5.bungee.api.plugin.Plugin
 import org.bstats.bungeecord.Metrics
+import net.md_5.bungee.api.plugin.Listener
+import net.md_5.bungee.event.EventHandler
+import net.md_5.bungee.api.event.ChatEvent
+import net.md_5.bungee.api.connection.ProxiedPlayer
+import net.md_5.bungee.api.plugin.Command
+import net.md_5.bungee.api.CommandSender
+import net.md_5.bungee.api.chat.ComponentBuilder
+import net.md_5.bungee.api.ChatColor
 
-class BungeeSlashServer : Plugin() {
+class BungeeSlashServer : Plugin(), Listener {
 
     private lateinit var config: Config
 
     override fun onEnable() {
         config = Config.loadConfig(dataFolder)
-        registerCommands()
+        proxy.pluginManager.registerListener(this, this)
+        
+        proxy.pluginManager.registerCommand(this, object : Command("slashserver", "slashserver.admin") {
+            override fun execute(sender: CommandSender, args: Array<out String>) {
+                if (args.size == 1 && args[0].equals("reload", ignoreCase = true)) {
+                    Config.reloadConfig(dataFolder, config)
+                    sender.sendMessage(*ComponentBuilder("SlashServer config reloaded!").color(ChatColor.GREEN).create())
+                } else {
+                    sender.sendMessage(*ComponentBuilder("Usage: /slashserver reload").color(ChatColor.RED).create())
+                }
+            }
+        })
 
         Metrics(this, 12510)
     }
 
     override fun onDisable() {
-
     }
 
-    private fun registerCommands() {
-        config.servers.forEach { s: ServerEntry ->
-            val list = s.commands.filter { alias -> s.server != alias }.toCollection(ArrayList())
-            proxy.pluginManager.registerCommand(
-                this,
-                BungeeNavigationCommand(s.server, s.permission, *list.toTypedArray())
-            )
+    @EventHandler
+    fun onChat(event: ChatEvent) {
+        if (!event.isCommand) return
+        val player = event.sender as? ProxiedPlayer ?: return
+
+        val cmd = event.message.split(" ")[0].substring(1).lowercase()
+        
+        config.servers.forEach { s ->
+            val aliases = s.commands.map { it.lowercase() } + s.server.lowercase()
+            if (aliases.contains(cmd)) {
+                if (s.disabledServers.contains(player.server.info.name)) {
+                    // Do nothing, let it go to backend
+                    return
+                } else {
+                    event.isCancelled = true
+                    if (player.hasPermission(s.permission)) {
+                        val server = proxy.getServerInfo(s.server)
+                        if (server != null) {
+                            player.connect(server)
+                        }
+                    }
+                    return
+                }
+            }
         }
     }
-
 }

--- a/src/main/kotlin/lv/mtm123/slashserver/proxies/VelocitySlashServer.kt
+++ b/src/main/kotlin/lv/mtm123/slashserver/proxies/VelocitySlashServer.kt
@@ -13,7 +13,7 @@ import java.io.File
 @Plugin(
     id = "slashserver",
     name = "SlashServer",
-    version = "@version@",
+    version = "1.2.0-SNAPSHOT",
     description = "Allows to use /<servername>",
     authors = ["MTM123"]
 )

--- a/src/main/kotlin/lv/mtm123/slashserver/proxies/VelocitySlashServer.kt
+++ b/src/main/kotlin/lv/mtm123/slashserver/proxies/VelocitySlashServer.kt
@@ -1,7 +1,8 @@
 package lv.mtm123.slashserver.proxies
 
-import com.google.inject.Inject
+import com.velocitypowered.api.command.SimpleCommand
 import com.velocitypowered.api.event.Subscribe
+import com.google.inject.Inject
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent
 import com.velocitypowered.api.plugin.Plugin
 import com.velocitypowered.api.proxy.ProxyServer
@@ -22,26 +23,60 @@ class VelocitySlashServer @Inject constructor(
     private val metricsFactory: Metrics.Factory
 ) {
 
+    private lateinit var config: Config
+    private lateinit var mainDir: File
+
     @Subscribe
     fun onInit(event: ProxyInitializeEvent) {
 
-        val mainDir = File("./plugins/SlashServer/")
+        mainDir = File("./plugins/SlashServer/")
         if (!mainDir.exists()) {
             mainDir.mkdirs()
         }
 
+        config = Config.loadConfig(mainDir)
         metricsFactory.make(this, 12509)
 
-        Config.loadConfig(mainDir).servers.forEach { s ->
+        registerCommands()
+
+        val adminMeta = proxy.commandManager.metaBuilder("slashserver").plugin(this).build()
+        proxy.commandManager.register(adminMeta, SimpleCommand { inv ->
+            if (inv.source().hasPermission("slashserver.admin") && inv.arguments().size == 1 && inv.arguments()[0].lowercase() == "reload") {
+                Config.reloadConfig(mainDir, config)
+                registerCommands()
+                inv.source().sendMessage(net.kyori.adventure.text.Component.text("SlashServer config reloaded!").color(net.kyori.adventure.text.format.NamedTextColor.GREEN))
+            } else if (inv.source().hasPermission("slashserver.admin")) {
+                inv.source().sendMessage(net.kyori.adventure.text.Component.text("Usage: /slashserver reload").color(net.kyori.adventure.text.format.NamedTextColor.RED))
+            }
+        })
+    }
+
+    private fun registerCommands() {
+        config.servers.forEach { s ->
             val meta = proxy.commandManager.metaBuilder(s.server)
                 .aliases(*s.commands.toTypedArray())
+                .plugin(this)
                 .build()
             proxy.commandManager.register(
                 meta,
                 VelocityNavigationCommand(proxy, s.server, s.permission)
             )
         }
+    }
 
+    @Subscribe
+    fun onCommandExecute(event: com.velocitypowered.api.event.command.CommandExecuteEvent) {
+        val player = event.commandSource as? com.velocitypowered.api.proxy.Player ?: return
+        val currentServer = player.currentServer.orElse(null)?.serverInfo?.name ?: return
+        
+        val cmd = event.command.split(" ")[0].lowercase()
+        config.servers.forEach { s ->
+            val aliases = s.commands + s.server
+            if (aliases.contains(cmd) && s.disabledServers.contains(currentServer)) {
+                event.result = com.velocitypowered.api.event.command.CommandExecuteEvent.CommandResult.forwardToServer()
+                return
+            }
+        }
     }
 
 }

--- a/src/main/kotlin/lv/mtm123/slashserver/util/Config.kt
+++ b/src/main/kotlin/lv/mtm123/slashserver/util/Config.kt
@@ -11,7 +11,7 @@ import java.nio.file.Paths
 class Config {
 
     @Setting
-    val servers = listOf(ServerEntry())
+    var servers = listOf(ServerEntry())
 
     companion object {
         fun loadConfig(pluginFolder: File): Config {
@@ -34,6 +34,21 @@ class Config {
             loader.save(ConfigTransform.update(node))
 
             return config
+        }
+
+        fun reloadConfig(pluginFolder: File, existingConfig: Config) {
+            val path = Paths.get(pluginFolder.path, "config.yml")
+            if (!path.toFile().exists()) return
+
+            val loader = YamlConfigurationLoader.builder()
+                .path(path)
+                .nodeStyle(NodeStyle.BLOCK)
+                .build()
+
+            val node = loader.load()
+            val newConfig = node.get(Config::class.java)!!
+            
+            existingConfig.servers = newConfig.servers
         }
     }
 

--- a/src/main/kotlin/lv/mtm123/slashserver/util/ServerEntry.kt
+++ b/src/main/kotlin/lv/mtm123/slashserver/util/ServerEntry.kt
@@ -15,4 +15,7 @@ class ServerEntry {
     @Setting
     val permission = "slashserver.server.lobby"
 
+    @Setting
+    val disabledServers = emptyList<String>()
+
 }


### PR DESCRIPTION
This pull request introduces several key improvements and refactors to both the Bungee and Velocity proxy implementations of the plugin, focusing on dynamic command registration, configuration reloading, and improved handling of disabled servers. The Gradle wrapper is also updated to a newer version. Below are the most important changes grouped by theme:

### Configuration Reloading and Management

* Added a `reloadConfig` method to `Config`, enabling in-place reloading of server configuration without restarting the proxy. Both Bungee and Velocity now support the `/slashserver reload` admin command to reload config at runtime. [[1]](diffhunk://#diff-b538b1c4567b3d943bfc4abc2a19959f55258b059484e523d800aac158d1ae16R38-R52) [[2]](diffhunk://#diff-5d92e66b984ce3dbcc314bbaa0c94a5efda48e83d560f522dc52f7624db78125L3-L33) [[3]](diffhunk://#diff-d82429a44811487b4e52b817f8f81232fe705e7489f09616f51d6630f44d1a7aR26-R79)

### Command Registration and Handling

* Refactored command registration for both Bungee and Velocity: commands are now registered dynamically based on the loaded config, and re-registered on config reload. [[1]](diffhunk://#diff-5d92e66b984ce3dbcc314bbaa0c94a5efda48e83d560f522dc52f7624db78125L3-L33) [[2]](diffhunk://#diff-d82429a44811487b4e52b817f8f81232fe705e7489f09616f51d6630f44d1a7aR26-R79)
* For Bungee, replaced the old command registration logic with an event-based handler that intercepts chat commands, checks permissions, and connects players to the appropriate server.
* For Velocity, added an event handler for command execution to properly forward commands to backend servers if the current server is disabled for a given command.

### Support for Disabled Servers

* Introduced a new `disabledServers` field in `ServerEntry` allowing specific servers to be excluded from command-based switching. This is enforced in both Bungee and Velocity implementations. [[1]](diffhunk://#diff-34dd9aa6671c7eb284e6ffdd9d51c14114ba362a7196a2b11c2df7a3f53256b5R18-R20) [[2]](diffhunk://#diff-5d92e66b984ce3dbcc314bbaa0c94a5efda48e83d560f522dc52f7624db78125L3-L33) [[3]](diffhunk://#diff-d82429a44811487b4e52b817f8f81232fe705e7489f09616f51d6630f44d1a7aR26-R79)

### Dependency and Version Updates

* Upgraded the Gradle wrapper from version 7.2 to 8.12.1 for improved build tooling and compatibility.

### Miscellaneous Improvements

* Updated the plugin version for Velocity to `1.2.0-SNAPSHOT` to reflect ongoing development.
* Made the `servers` property in `Config` mutable to support reloading.